### PR TITLE
package.json: repair numbering este version. 3.5 => 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "este",
-  "version": "3.5",
+  "version": "3.5.0",
   "description": "Este is robust, modular and comfortable dev stack for web apps development with several unique features",
   "author": "Daniel Steigerwald <daniel@steigerwald.cz>",
   "keywords": [


### PR DESCRIPTION
$ git pull <master>
$ npm install

```
npm ERR! install Couldn't read dependencies
npm ERR! Error: invalid version: 3.5
npm ERR!     at validVersion (/usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:571:40)
npm ERR!     at final (/usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:323:23)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:139:33
npm ERR!     at cb (/usr/local/lib/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-package-json/read-json.js:316:40
npm ERR!     at fs.js:266:14
npm ERR!     at Object.oncomplete (fs.js:107:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>

npm ERR! System Darwin 12.4.0
npm ERR! command "node" "/usr/local/bin/npm" "install"
npm ERR! cwd /Volumes/HTDOCS/este
npm ERR! node -v v0.10.5
npm ERR! npm -v 1.2.18
npm ERR!
npm ERR! Additional logging details can be found in:
npm ERR!     /Volumes/HTDOCS/este/npm-debug.log
npm ERR! not ok code 0
```
