### PR TITLE
NoErrorsPlugin is not needed with hot/only-dev-server

### DIFF
--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -94,9 +94,7 @@ module.exports = function(isDevelopment) {
       if (isDevelopment)
         plugins.push(
           NotifyPlugin,
-          new webpack.HotModuleReplacementPlugin(),
-          // Tell reloader to not reload if there is an error.
-          new webpack.NoErrorsPlugin()
+          new webpack.HotModuleReplacementPlugin()
         );
       else
         plugins.push(


### PR DESCRIPTION
This is something silly I've been doing and recommending for a long time. Sorry! There's no need for `NoErrorsPlugin` if you use `hot/only-dev-server`. Hot updates won't blow your app away if you make a syntax error, but at least you'll see the error in the DevTools console! And the subsequent hot updates will just work when you fix that error.

Please verify that this is indeed the case for you. (I don't know, it certainly works this way for my projects, but then maybe Webpack changed the behavior in some version? Just make sure it really works as I describe above.)