### PR TITLE
Enhancements on npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npm install
 
 ## CI Tasks
 
-- `npm start` just run app, remember to set NODE_ENV=production and others environment variables.
+- `npm start` just alias for `gulp server --production`
 - `npm postinstall` just alias for `gulp build --production`, useful for Heroku.
 - `npm test` just alias for `gulp test`
 
@@ -87,9 +87,9 @@ application architecture](https://medium.com/brigade-engineering/what-is-the-flu
 - [twitter.com/estejs](https://twitter.com/estejs)
 - [github.com/enaqx/awesome-react](https://github.com/enaqx/awesome-react)
 
-## Tips and Tricks 
+## Tips and Tricks
 
-- To check app state, press `ctrl+shift+s`, and then open console. 
+- To check app state, press `ctrl+shift+s`, and then open console.
 - To check app render time, open console, and write `este.measureRender = true`.
 - With global app state, we don't need IoC container so badly - [SOLID: the next step is Functional](http://blog.ploeh.dk/2014/03/10/solid-the-next-step-is-functional). Still DI is relevant for some cases and then use [Pure DI](http://blog.ploeh.dk/2014/06/10/pure-di/).
 - Use `const` by default, `let` if you have to rebind a variable.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "postinstall": "gulp build --production",
-    "start": "node src/server",
+    "start": "gulp server --production",
     "test": "gulp test"
   },
   "engines": {


### PR DESCRIPTION
Hi,

Due to the `Error: Environment variable NODE_ENV must be set.` every time `npm start` is executed, I think it is better to change the script to make it more consistent with the `npm postinstall` and less confusing.

The gulp `env` task is already setting `NODE_ENV` anyway...

What do you think?

Thanks!