### PR TITLE
Upgrade to react-router 1.0.0-beta1

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -67,5 +67,5 @@ gulp.task('default', (done) => {
   if (args.production)
     runSequence('server', done);
   else
-    runSequence('server', 'karma-dev', done);
+    runSequence('server', done);
 });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-hot-loader": "^1.1.4",
     "react-intl": "^1.1.0",
     "react-pure-render": "^1.0.1",
-    "react-router": "^0.13.1",
+    "react-router": "^1.0.0-beta1",
     "react-textarea-autosize": "^2.3.1",
     "run-sequence": "^1.0.2",
     "sass-loader": "^1.0.0",

--- a/src/client/app/app.react.js
+++ b/src/client/app/app.react.js
@@ -37,6 +37,7 @@ export default class App extends Component {
   }
 
   render() {
+    // TODO remove when not needed
     const children = React.cloneElement(this.props.children, this.state);
 
     return (

--- a/src/client/app/app.react.js
+++ b/src/client/app/app.react.js
@@ -3,7 +3,6 @@ import Component from '../components/component.react';
 import Footer from './footer.react';
 import Header from './header.react';
 import React from 'react';
-import {RouteHandler} from 'react-router';
 import {appState} from '../state';
 import {measureRender} from '../console';
 

--- a/src/client/app/app.react.js
+++ b/src/client/app/app.react.js
@@ -38,10 +38,12 @@ export default class App extends Component {
   }
 
   render() {
+    const children = React.cloneElement(this.props.children, this.state);
+
     return (
       <div className="page">
         <Header isLoggedIn={this.state.isLoggedIn} />
-        <RouteHandler {...this.state} />
+        {children}
         <Footer />
       </div>
     );

--- a/src/client/app/header.react.js
+++ b/src/client/app/header.react.js
@@ -19,12 +19,12 @@ export default class Header extends Component {
           <FormattedHTMLMessage message={msg('app.header.h1Html')} />
         </h1>
         <ul>
-          <li><Link to="home">{msg('app.header.home')}</Link></li>
-          <li><Link to="todos">{msg('app.header.todos')}</Link></li>
-          <li><Link to="examples">{msg('app.header.examples')}</Link></li>
-          <li><Link to="me">{msg('app.header.me')}</Link></li>
+          <li><Link to="/home">{msg('app.header.home')}</Link></li>
+          <li><Link to="/todos">{msg('app.header.todos')}</Link></li>
+          <li><Link to="/examples">{msg('app.header.examples')}</Link></li>
+          <li><Link to="/me">{msg('app.header.me')}</Link></li>
           {!isLoggedIn &&
-            <li><Link to="login">{msg('app.header.login')}</Link></li>
+            <li><Link to="/login">{msg('app.header.login')}</Link></li>
           }
         </ul>
       </header>

--- a/src/client/auth/login.react.js
+++ b/src/client/auth/login.react.js
@@ -13,7 +13,7 @@ export default class Login extends Component {
   static propTypes = {
     auth: React.PropTypes.instanceOf(immutable.Map).isRequired,
     pendingActions: React.PropTypes.instanceOf(immutable.Map).isRequired,
-    router: React.PropTypes.func
+    router: React.PropTypes.object.isRequired
   };
 
   getForm() {
@@ -31,9 +31,8 @@ export default class Login extends Component {
   }
 
   redirectAfterLogin() {
-    const {router} = this.props;
-    const nextPath = router.getCurrentQuery().nextPath;
-    router.replaceWith(nextPath || 'home');
+    const {location: {query: {nextPath}}, router} = this.props;
+    router.replaceWith(nextPath || '/');
   }
 
   render() {

--- a/src/client/auth/requireauth.js
+++ b/src/client/auth/requireauth.js
@@ -1,0 +1,11 @@
+import {usersCursor} from '../state';
+
+export default function requireAuth(nextState, transition) {
+  const isLoggedIn = !!usersCursor().get('viewer');
+  if (isLoggedIn) return;
+
+  // TODO this does not work on server side - throw an Error?
+  transition.to('/login', {}, {
+    nextPath: transition.path
+  });
+}

--- a/src/client/components/component.react.js
+++ b/src/client/components/component.react.js
@@ -17,9 +17,9 @@ export default class Component extends React.Component {
     // TODO: Make whole React Pure, add something like dangerouslySetLocalState.
     // https://github.com/gaearon/react-pure-render#known-issues
     // https://twitter.com/steida/status/600395820295450624
-    if (this.context.router) {
-      const changed = this.pureComponentLastPath !== this.context.router.getCurrentPath();
-      this.pureComponentLastPath = this.context.router.getCurrentPath();
+    if (this.props.location) {
+      const changed = this.pureComponentLastPath !== this.props.location.pathname;
+      this.pureComponentLastPath = this.props.location.pathname;
       if (changed) return true;
     }
 

--- a/src/client/components/exposerouter.react.js
+++ b/src/client/components/exposerouter.react.js
@@ -6,7 +6,7 @@ export default function exposeRouter(BaseComponent) {
   return class ExposeRouter extends Component {
 
     static contextTypes = {
-      router: React.PropTypes.func.isRequired
+      router: React.PropTypes.object.isRequired
     };
 
     static displayName = `${BaseComponent.name}ExposeRouter`;
@@ -18,4 +18,3 @@ export default function exposeRouter(BaseComponent) {
   };
 
 }
-

--- a/src/client/components/requeststate.react.js
+++ b/src/client/components/requeststate.react.js
@@ -1,0 +1,48 @@
+import Component from '../components/component.react';
+import React from 'react';
+import {appState} from '../state';
+
+// Higher order component.
+// https://medium.com/@dan_abramov/mixins-are-dead-long-live-higher-order-components-94a0d2f9e750
+export default function requestState(stateProps) {
+
+  return function(BaseComponent) {
+    class StateContainer extends Component {
+      constructor(props) {
+        super(props)
+        this.handleStateChange = this.handleStateChange.bind(this)
+        this.state = this.getState()
+      }
+
+      getState(transition) {
+        return Object.keys(stateProps).reduce((localState, propName) => {
+          const propKeyPath = stateProps[propName]
+          localState[propName] = appState.get().getIn(propKeyPath)
+          return localState
+        }, {})
+      }
+
+      componentWillMount() {
+        if (process.env.IS_BROWSER) appState.on('change', this.handleStateChange)
+      }
+
+      componentWillUnmount() {
+        appState.removeListener('change', this.handleStateChange)
+      }
+
+      handleStateChange() {
+        this.setState(this.getState())
+      }
+
+      render() {
+        return <BaseComponent {...this.props} {...this.state} />;
+      }
+
+    }
+
+    StateContainer.displayName = `${BaseComponent.name}StateContainer`;
+
+    return StateContainer;
+  }
+
+}

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import Router from 'react-router';
 import routes from './routes';
+import {history} from 'react-router/lib/BrowserHistory';
 import {measureRender} from './console';
+import {Router} from 'react-router';
 
 const app = document.getElementById('app');
 
-Router.run(routes, Router.HistoryLocation, (Handler) => {
-  measureRender(done => React.render(<Handler />, app, done));
-});
+// TODO measure route render - is it even possible now?
+
+React.render(<Router children={routes} history={history} />, app);

--- a/src/client/pages/examples.react.js
+++ b/src/client/pages/examples.react.js
@@ -2,10 +2,15 @@ import * as actions from '../examples/actions';
 import Component from '../components/component.react';
 import DocumentTitle from 'react-document-title';
 import Editable from '../components/editable.react';
-import React from 'react';
 import immutable from 'immutable';
+import React from 'react';
+import requestState from '../components/requeststate.react';
 import {msg} from '../intl/store';
 
+@requestState({
+  examples: ['examples'],
+  pendingActions: ['pendingActions']
+})
 export default class Examples extends Component {
 
   static propTypes = {

--- a/src/client/pages/home.react.js
+++ b/src/client/pages/home.react.js
@@ -13,7 +13,7 @@ export default class Home extends Component {
         <div className="home-page">
           <p>
             <FormattedHTMLMessage message={msg('pages.home.infoHtml')} />{' '}
-            <Link to="todos">{msg('pages.home.todos')}</Link>.
+            <Link to="/todos">{msg('pages.home.todos')}</Link>.
           </p>
         </div>
       </DocumentTitle>

--- a/src/client/pages/me.react.js
+++ b/src/client/pages/me.react.js
@@ -3,10 +3,8 @@ import DocumentTitle from 'react-document-title';
 import Logout from '../auth/logout.react';
 import React from 'react';
 import immutable from 'immutable';
-import requireAuth from '../auth/requireauth.react';
 import {msg} from '../intl/store';
 
-@requireAuth
 export default class Me extends Component {
 
   static propTypes = {

--- a/src/client/pages/notfound.react.js
+++ b/src/client/pages/notfound.react.js
@@ -12,7 +12,7 @@ export default class NotFound extends Component {
         <div className="notfound-page">
           <h1>{msg('pages.notFound.header')}</h1>
           <p>{msg('pages.notFound.message')}</p>
-          <Link to="home">{msg('pages.notFound.continueMessage')}</Link>
+          <Link to="/home">{msg('pages.notFound.continueMessage')}</Link>
         </div>
       </DocumentTitle>
     );

--- a/src/client/pages/todos.react.js
+++ b/src/client/pages/todos.react.js
@@ -1,5 +1,6 @@
 import Buttons from '../todos/buttons.react';
 import Component from '../components/component.react';
+import requestState from '../components/requeststate.react';
 import DocumentTitle from 'react-document-title';
 import List from '../todos/list.react';
 import NewTodo from '../todos/newtodo.react';
@@ -8,6 +9,10 @@ import ToCheck from './tocheck.react';
 import immutable from 'immutable';
 import {msg} from '../intl/store';
 
+@requestState({
+  pendingActions: ['pendingActions'],
+  todos: ['todos']
+})
 export default class Todos extends Component {
 
   static propTypes = {

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -6,15 +6,15 @@ import Me from './pages/me.react';
 import NotFound from './pages/notfound.react';
 import React from 'react';
 import Todos from './pages/todos.react';
-import {DefaultRoute, NotFoundRoute, Route} from 'react-router';
+import {Route} from 'react-router';
 
 export default (
-  <Route handler={App} path="/">
-    <DefaultRoute handler={Home} name="home" />
-    <NotFoundRoute handler={NotFound} name="not-found" />
-    <Route handler={Examples} name="examples" />
-    <Route handler={Login} name="login" />
-    <Route handler={Me} name="me" />
-    <Route handler={Todos} name="todos" />
+  <Route component={App}>
+    <Route component={Home} path="/" />
+    <Route component={Examples} path="examples" />
+    <Route component={Login} path="login" />
+    <Route component={Me} path="me" />
+    <Route component={Todos} path="todos" />
+    <Route component={NotFound} path="*" />
   </Route>
 );

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -5,6 +5,7 @@ import Login from './pages/login.react';
 import Me from './pages/me.react';
 import NotFound from './pages/notfound.react';
 import React from 'react';
+import requireAuth from './auth/requireauth';
 import Todos from './pages/todos.react';
 import {Route} from 'react-router';
 
@@ -13,7 +14,7 @@ export default (
     <Route component={Home} path="/" />
     <Route component={Examples} path="examples" />
     <Route component={Login} path="login" />
-    <Route component={Me} path="me" />
+    <Route component={Me} path="me" onEnter={requireAuth} />
     <Route component={Todos} path="todos" />
     <Route component={NotFound} path="*" />
   </Route>


### PR DESCRIPTION
I am pretty excited about the possibilities that the new Router gives us after I saw the presentation on ReactEurope. I know that is it still beta, but I would like to migrate Este to it ASAP (we could have a branch supporting it until it is out of beta). I've already spent a few hours on this - not as easy as I thought. The new version includes a lot of changes. The whole react-router library feels "cleaner" and much more mature then previous version.

This is still WIP. I was able to make server rendering work and render the app on client side as well.

TODO:
- [ ] Error handling (onAbort, onError)
- [ ] Check if `pureComponentLastPath` is still needed
- [ ] `transition.to` does not work when rendering on server
- [ ] Remove child cloning and setState from App component (waiting for ideas from @steida and @grabbou)
- [x] Remove `contextTypes` and use passed props.
- [x] What to do with failed prop checks (all components under App are rendered twice)?
- [x] Migrate from `componentWillTransitionTo` to `onEnter`
- [x] Named routes are gone (or I missed something?), use the pathnames directly when rendering `Link`
- [x] Rename some vars in `frontend/render` (Handler) to match their content

TODO later: :wink:
- Maybe Include example of [`AsyncProps`](https://github.com/rackt/react-router/tree/dec7558fb01eb685d9a023b13dfc149de600bd01/examples/async-data) in Este?

- I do not much like the way I am passing the props to components from App (although it is taken from [router's examples](https://github.com/rackt/react-router/blob/dec7558fb01eb685d9a023b13dfc149de600bd01/examples/passing-props-to-children/app.js). ~~I think I have a better way for this, but I'll try to explore that in different PR.~~ We need to do this in this PR, otherwise we will be getting errors from Route handlers (they will be rendered twice, first with props, then without)

- Add example of async loading of modules

