### PR TITLE
Server side language polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "immutable": "^3.6.4",
     "immutablediff": "^0.4.2",
     "intl": "0.1.4",
+    "intl-locales-supported": "^1.0.0",
     "intl-messageformat": "^1.1.0",
     "intl-relativeformat": "^1.1.0",
     "karma": "0.12.36",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,12 +1,22 @@
+var areIntlLocalesSupported = require('intl-locales-supported');
 const config = require('./config');
 
 if (config.isProduction || require('piping')(config.piping)) {
   if (!process.env.NODE_ENV)
     throw new Error('Environment variable NODE_ENV isn\'t set. Remember it\'s up your production enviroment to set NODE_ENV and maybe other variables. To run app locally in production mode, use gulp -p command instead.');
 
-  // Load and use polyfill for ECMA-402.
-  if (!global.Intl)
+  if (global.Intl) {
+    // Use polyfill if language support for required languages is missing.
+    // See: http://formatjs.io/guides/runtime-environments/#polyfill-node
+    if (!areIntlLocalesSupported(config.appLocales)) {
+      const IntlPolyfill = require('intl');
+      global.Intl.NumberFormat = IntlPolyfill.NumberFormat;
+      global.Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+    }
+  } else {
+    // No `Intl`, so load and use polyfill for ECMA-402.
     global.Intl = require('intl');
+  }
 
   require('babel/register')({optional: ['es7']});
 


### PR DESCRIPTION
I found that there's no language support on node apart from English. As they state on format.js (see: http://formatjs.io/guides/runtime-environments/#polyfill-node):

_Node.js 0.12 does [have Intl build-in], but the default build/distribution only supports English._

This PR allows other locales to be support on the server if needed.