### PR TITLE
Show all eslint errors even if eslint fails.

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -51,7 +51,7 @@ gulp.task('eslint', () => {
 
 gulp.task('eslint-ci', () => {
   // Exit process with an error code (1) on lint error for CI build.
-  return runEslint().pipe(eslint.failOnError());
+  return runEslint().pipe(eslint.failAfterError());
 });
 
 gulp.task('karma-ci', (done) => {


### PR DESCRIPTION
When using eslint.failAfterError, we get list of all eslint errors before the gulp task fails.