### PR TITLE
Fix Sass loader w/ indented syntax

### DIFF
--- a/webpack/makeconfig.js
+++ b/webpack/makeconfig.js
@@ -17,7 +17,8 @@ var devtools = process.env.CONTINUOUS_INTEGRATION
 var loaders = {
   'css': '',
   'less': '!less-loader',
-  'scss|sass': '!sass-loader',
+  'scss': '!sass-loader',
+  'sass': '!sass-loader?indentedSyntax',
   'styl': '!stylus-loader'
 };
 


### PR DESCRIPTION
This way it's easier to distinguish between SCSS and SASS files.