### PR TITLE
Comment out karma temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,48 @@
 
 > The most complete React/Flux dev stack and starter kit for universal functional web apps. Forget about [evil frameworks](http://tomasp.net/blog/2015/library-frameworks/), learn laser focused libraries and patterns instead.
 
+## At a glance
+
+Este universe is organized into several folders, each of them contains its own package.json.
+
+#### @este/universal
+
+This is umbrella package to help you working with different targets.
+You should not install any dependencies here. The only dependencies that are included in that
+package are eslint and its parsers so it's easier to work with Atom/SublimeText.
+
+This package contains several scripts that are here to help you with development, but since they are just wrappers
+to the underlaying `web/` and `native/` tasks, it's not required to use them. See Dev and CI tasks section.
+
+#### @este/common
+
+Este common is a package that contains Flux (Redux) implementation, actions, reducers and universal logic that works
+across all targets. You should not install any React-specific or target-specific dependencies here to make this
+package fully cross-platform.
+
+#### @este/web
+
+This package contains previous Este/web and comes with both client and server.
+
+#### @este/native
+
+This package contains previous Este/native and comes with React Native iOS & Android implementations.
+
+## Prerequisites
+
+Install [node.js](http://nodejs.org) (v4 is required).
+Then install [gulp.js](http://gulpjs.com/).
+```shell
+npm install -g gulp
+```
+
+If you are using different node versions on your machine, use `nvm` to manage them.
+
+You may also need to upgrade `npm` to 3.x
+```shell
+npm install -g npm@3.x
+```
+
 ## Techniques
 
 - Universal JavaScript dev stack for browser, server, mobile.
@@ -24,27 +66,7 @@
 - LESS, SASS, Stylus, or plain CSS with [autoprefixer](https://github.com/postcss/autoprefixer).
 - Long Term Caching through file hashes.
 
-## Prerequisites
-
-Install [node.js](http://nodejs.org) (v4 is required).
-Then install [gulp.js](http://gulpjs.com/).
-```shell
-npm install -g gulp
-```
-
-If you are using different node versions on your machine, use `nvm` to manage them.
-
-#### Windows
-
-Use this if you are using JEST or another library, which has to be compiled.
-
-- Install Python - Install version 2.7 of Python and add it to your path or/and create a PYTHONPATH environment variable.
-- Install Visual Studio (Express Edition is fine) - We will need this for some of modules that are compiled when we are installing Este. [Download VS Express](https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx), get one of the versions that has C++ - Express 2013 for Windows Desktop for example.
-- Set Visual Studio Version Flags - We need to tell node-gyp (something that is used for compiling addons) what version of Visual Studio we want to compile with. You can do this either through an environment variable GYP_MSVS_VERSION. If you are using Express, you have to say GYP_MSVS_VERSION=2013e.
-
-Thanks to [Ryanlanciaux](http://ryanlanciaux.github.io/blog/2014/08/02/using-jest-for-testing-react-components-on-windows/)
-
-## Create App
+## Installing
 
 ```shell
 git clone https://github.com/este/este.git este-app
@@ -81,6 +103,16 @@ application architecture](https://medium.com/brigade-engineering/what-is-the-flu
 - [wiki: Recommended Sublime Text 3 Packages](https://github.com/steida/este/wiki/Recommended-Sublime-Text-3-settings)
 - [twitter.com/estejs](https://twitter.com/estejs)
 - [github.com/enaqx/awesome-react](https://github.com/enaqx/awesome-react)
+
+## Windows
+
+Use this if you are using JEST or another library, which has to be compiled.
+
+- Install Python - Install version 2.7 of Python and add it to your path or/and create a PYTHONPATH environment variable.
+- Install Visual Studio (Express Edition is fine) - We will need this for some of modules that are compiled when we are installing Este. [Download VS Express](https://www.visualstudio.com/en-us/products/visual-studio-express-vs.aspx), get one of the versions that has C++ - Express 2013 for Windows Desktop for example.
+- Set Visual Studio Version Flags - We need to tell node-gyp (something that is used for compiling addons) what version of Visual Studio we want to compile with. You can do this either through an environment variable GYP_MSVS_VERSION. If you are using Express, you have to say GYP_MSVS_VERSION=2013e.
+
+Thanks to [Ryanlanciaux](http://ryanlanciaux.github.io/blog/2014/08/02/using-jest-for-testing-react-components-on-windows/)
 
 ## Tips and Tricks
 
@@ -126,4 +158,4 @@ Pure means no side effects. Programming without side effects rocks. It allows us
 
 <img alt="Este.js" src="https://cloud.githubusercontent.com/assets/66249/6515278/de638916-c388-11e4-8754-184f5b11e770.jpeg" width="200">
 
-made by Daniel Steigerwald, [twitter.com/steida](https://twitter.com/steida)
+made by Daniel Steigerwald, [twitter.com/steida](https://twitter.com/steida), @grabbou and the community

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Thanks to [Ryanlanciaux](http://ryanlanciaux.github.io/blog/2014/08/02/using-jes
 - When `gulp` command fails with `No gulpfile found`. Problem is with gulp version on your system. Simple fix: https://github.com/gulpjs/gulp-cli/issues/27#issuecomment-116134527
 
 ## FAQ
+
 #### Why does the CSS flicker when starting the app/refreshing it?
 In dev mode, webpack loads all the style inline, which makes them hot reloadable. This behaviour disappears in production mode (`gulp -p`).
 
@@ -136,9 +137,6 @@ Yes. Este makes little assumptions about your stack, and passing every bit of ne
 
 #### Do you have any other example apps using Este?
 Right now, there are little open sourced apps on the web (if you have any example, feel free to send a PR, or tip us on Gitter). You can have a look at the other repositories of the [este organization](http://github.com/este). You might for instance find some interesting stuff in [este-firebase](https://github.com/este/este-firebase/).
-
-#### Does it work with React Native?
-Yes! Check the [native](https://github.com/este/native) repo.
 
 #### Why Este is pure and why we have to pass data through props?
 Pure means no side effects. Programming without side effects rocks. It allows us to hot reload everything and testing is much easier as well. When component renders only data passed through props, [shouldComponentUpdate](https://facebook.github.io/react/docs/component-specs.html#updating-shouldcomponentupdate) can be implemented [only once](https://github.com/este/este/blob/d08556dd1e4d57b4c0e605e3395ce6af9963910e/src/client/components/component.react.js#L14) per whole app. One can say it's verbose, but it isn't. It's explicit. And remember, we have to pass only data going to be rendered. Actions have access to app state.

--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,5 @@ machine:
   node:
     version: 4.0.0
   post:
+    - npm install -g gulp
     - npm install -g npm@3.x.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@este/universal",
-  "description": "Universal Este app",
+  "description": "Universal Este app.",
   "authors": [
     "Daniel Steigerwald",
     "Mike Grabowski"
@@ -21,10 +21,8 @@
     "npm": "^3.0.0"
   },
   "dependencies": {
-    "babel": "^5.0.8",
-    "babel-core": "^5.0.8",
-    "babel-eslint": "^4.1.2",
     "eslint": "^1.4.1",
-    "eslint-plugin-react": "^3.3.2"
+    "eslint-plugin-react": "^3.3.2",
+    "babel-eslint": "^4.1.2"
   }
 }

--- a/web/gulpfile.babel.js
+++ b/web/gulpfile.babel.js
@@ -1,23 +1,24 @@
 import bg from 'gulp-bg';
 import eslint from 'gulp-eslint';
 import gulp from 'gulp';
-import path from 'path';
 import runSequence from 'run-sequence';
 import webpackBuild from './webpack/build';
 import yargs from 'yargs';
-import {Server as KarmaServer} from 'karma';
+
+// import path from 'path';
+// import {Server as KarmaServer} from 'karma';
 
 const args = yargs
   .alias('p', 'production')
   .argv;
 
-const runKarma = ({singleRun}, done) => {
-  const server = new KarmaServer({
-    configFile: path.join(__dirname, 'karma.conf.js'), // eslint-disable-line no-undef
-    singleRun: singleRun
-  }, done);
-  server.start();
-};
+// const runKarma = ({singleRun}, done) => {
+//   const server = new KarmaServer({
+//     configFile: path.join(__dirname, 'karma.conf.js'), // eslint-disable-line no-undef
+//     singleRun: singleRun
+//   }, done);
+//   server.start();
+// };
 
 const runEslint = () => {
   return gulp.src([
@@ -46,14 +47,14 @@ gulp.task('eslint-ci', () => {
   // Exit process with an error code (1) on lint error for CI build.
   return runEslint().pipe(eslint.failAfterError());
 });
-
-gulp.task('karma-ci', (done) => {
-  runKarma({singleRun: true}, done);
-});
-
-gulp.task('karma', (done) => {
-  runKarma({singleRun: false}, done);
-});
+//
+// gulp.task('karma-ci', (done) => {
+//   runKarma({singleRun: true}, done);
+// });
+//
+// gulp.task('karma', (done) => {
+//   runKarma({singleRun: false}, done);
+// });
 
 gulp.task('test', (done) => {
   // TODO: Fix 'karma-ci'
@@ -62,9 +63,9 @@ gulp.task('test', (done) => {
 
 gulp.task('server', ['env', 'build'], bg('node', './src/server'));
 
-gulp.task('tdd', (done) => {
-  // Run karma configured for TDD.
-  runSequence('server', 'karma', done);
-});
+// gulp.task('tdd', (done) => {
+//   // Run karma configured for TDD.
+//   runSequence('server', 'karma', done);
+// });
 
 gulp.task('default', ['server']);

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,8 @@
   },
   "version": "1.0.0-rc1",
   "dependencies": {
+    "babel": "^5.0.8",
+    "babel-core": "^5.0.8",
     "@este/common": "1.0.0-rc1",
     "autoprefixer": "^6.0.2",
     "babel-plugin-react-transform": "^1.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -50,14 +50,6 @@
     "intl-relativeformat": "^1.1.0",
     "invariant": "^2.1.0",
     "isomorphic-fetch": "^2.1.1",
-    "karma": "^0.13.3",
-    "karma-chai": "^0.1.0",
-    "karma-chrome-launcher": "^0.2.0",
-    "karma-coverage": "^0.5.0",
-    "karma-mocha": "^0.2.0",
-    "karma-notify-reporter": "^0.1.1",
-    "karma-sourcemap-loader": "^0.3.5",
-    "karma-webpack": "^1.7.0",
     "less": "^2.5.1",
     "less-loader": "^2.0.0",
     "mocha": "^2.2.5",
@@ -93,5 +85,15 @@
     "webpack-hot-middleware": "^2.1.0",
     "babel-loader": "^5.0.0",
     "yargs": "^3.3.1"
+  },
+  "disabledDependencies": {
+    "karma": "^0.13.3",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^0.2.0",
+    "karma-coverage": "^0.5.0",
+    "karma-mocha": "^0.2.0",
+    "karma-notify-reporter": "^0.1.1",
+    "karma-sourcemap-loader": "^0.3.5",
+    "karma-webpack": "^1.7.0"
   }
 }


### PR DESCRIPTION
Because karma requires socket.io that does not support Node.js 4.0 - this produces warnings in `npm install` when node-gyp builds native modules. It has no impact on production and development because we do not use Karma at all, so decided to comment it out to get rid of these errors.

Karma dependencies were moved to custom `disabledDependencies` field just to not forget about them once we re-enable it back again.