### PR TITLE
Support Windows and better server reloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   ],
   "private": true,
   "scripts": {
-    "preinstall": "(cd web; npm link ../common); (cd native; npm link ../common)",
-    "postinstall": "(cd web; npm install); (cd native; npm install)",
+    "preinstall": "(cd web; npm link ../common; cd ..); (cd native; npm link ../common; cd ..)",
+    "postinstall": "(cd web; npm install; cd ..); (cd native; npm install; cd ..)",
     "start": "echo Please use `npm run web-start` to start a server",
     "web-start": "(cd web; npm start)",
     "web-start-dev": "(cd web; npm run start-dev)",
     "web-build": "(cd web; npm run build)",
-    "native-start": "",
+    "native-start": "echo Please use XCode / Android IDE to run your build",
     "test": "(cd web; npm test)"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preinstall": "(cd web; npm link ../common); (cd native; npm link ../common)",
     "postinstall": "(cd web; npm install); (cd native; npm install)",
     "start": "echo Please use `npm run web-start` to start a server",
-    "web-start": "(cd web && npm start)",
+    "web-start": "(cd web; npm start)",
     "web-start-dev": "(cd web; npm run start-dev)",
     "web-build": "(cd web; npm run build)",
     "native-start": "",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   ],
   "private": true,
   "scripts": {
-    "preinstall": "(cd web && npm link ../common) && (cd native && npm link ../common)",
-    "postinstall": "(cd web && npm install) && (cd native && npm install)",
+    "preinstall": "(cd web; npm link ../common); (cd native; npm link ../common)",
+    "postinstall": "(cd web; npm install); (cd native; npm install)",
     "start": "echo Please use `npm run web-start` to start a server",
     "web-start": "(cd web && npm start)",
-    "web-start-dev": "(cd web && npm run start-dev)",
-    "web-build": "(cd web && npm run build)",
+    "web-start-dev": "(cd web; npm run start-dev)",
+    "web-build": "(cd web; npm run build)",
     "native-start": "",
-    "test": "(cd web && npm test)"
+    "test": "(cd web; npm test)"
   },
   "engines": {
     "node": "^4.0.0",

--- a/web/gulpfile.babel.js
+++ b/web/gulpfile.babel.js
@@ -61,7 +61,7 @@ gulp.task('test', (done) => {
   runSequence('eslint-ci', 'build-webpack', done);
 });
 
-gulp.task('server', ['env', 'build'], bg('node', './src/server'));
+gulp.task('server', ['env', 'build'], bg('./node_modules/.bin/nodemon', './src/server'));
 
 // gulp.task('tdd', (done) => {
 //   // Run karma configured for TDD.

--- a/web/nodemon.json
+++ b/web/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "verbose": true,
+  "ignore": ["src/client/**", "../common"]
+}

--- a/web/package.json
+++ b/web/package.json
@@ -59,7 +59,6 @@
     "node-sass": "^3.1.2",
     "normalize.css": "^3.0.2",
     "nyan-progress-webpack-plugin": "^1.0.0",
-    "piping": "^0.2.0",
     "postcss-loader": "^0.6.0",
     "react": "^0.14.0-rc1",
     "react-document-title": "^2.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -97,5 +97,8 @@
     "karma-notify-reporter": "^0.1.1",
     "karma-sourcemap-loader": "^0.3.5",
     "karma-webpack": "^1.7.0"
+  },
+  "devDependencies": {
+    "nodemon": "^1.7.0"
   }
 }

--- a/web/src/server/config.js
+++ b/web/src/server/config.js
@@ -16,17 +16,6 @@ var config = {
   defaultLocale: 'en',
   googleAnalyticsId: 'UA-XXXXXXX-X',
   isProduction: isProduction,
-  piping: {
-    // Ignore webpack custom loaders on server. TODO: Reuse index.js config.
-    ignore: /(\/\.|~$|\.(css|less|sass|scss|styl))/,
-    // Hook false ensures server is restarted only on server files change.
-    // True would restart server on any file change, but it doesn't work with
-    // hot reloading. This means browser reload will always get stale react
-    // components which results to React attempted to reuse markup warning.
-    // But that's fine, because with new react-transform we don't have to
-    // reload browser during development anymore.
-    hook: false
-  },
   port: process.env.PORT || 8000,
   webpackStylesExtensions: ['css', 'less', 'sass', 'scss', 'styl']
 };

--- a/web/src/server/index.js
+++ b/web/src/server/index.js
@@ -1,30 +1,28 @@
 const areIntlLocalesSupported = require('intl-locales-supported');
 const config = require('./config');
 
-if (config.isProduction || require('piping')(config.piping)) {
-  if (!process.env.NODE_ENV)
-    throw new Error('Environment variable NODE_ENV isn\'t set. Remember it\'s up your production enviroment to set NODE_ENV and maybe other variables. To run app locally in production mode, use gulp -p command instead.');
+if (!process.env.NODE_ENV)
+  throw new Error('Environment variable NODE_ENV isn\'t set. Remember it\'s up your production enviroment to set NODE_ENV and maybe other variables. To run app locally in production mode, use gulp -p command instead.');
 
-  if (global.Intl) {
-    // Determine if the built-in `Intl` has the locale data we need.
-    if (!areIntlLocalesSupported(config.appLocales)) {
-      // `Intl` exists, but it doesn't have the data we need, so load the
-      // polyfill and replace the constructors we need with the polyfill's.
-      require('intl');
-      global.Intl.NumberFormat = global.IntlPolyfill.NumberFormat;
-      global.Intl.DateTimeFormat = global.IntlPolyfill.DateTimeFormat;
-    }
-  } else {
-    // No `Intl`, so use and load the polyfill.
-    global.Intl = require('intl');
+if (global.Intl) {
+  // Determine if the built-in `Intl` has the locale data we need.
+  if (!areIntlLocalesSupported(config.appLocales)) {
+    // `Intl` exists, but it doesn't have the data we need, so load the
+    // polyfill and replace the constructors we need with the polyfill's.
+    require('intl');
+    global.Intl.NumberFormat = global.IntlPolyfill.NumberFormat;
+    global.Intl.DateTimeFormat = global.IntlPolyfill.DateTimeFormat;
   }
-
-  require('babel/register')({optional: ['es7']});
-
-  // To ignore webpack custom loaders on server.
-  config.webpackStylesExtensions.forEach(function(ext) {
-    require.extensions['.' + ext] = function() {};
-  });
-
-  require('./main');
+} else {
+  // No `Intl`, so use and load the polyfill.
+  global.Intl = require('intl');
 }
+
+require('babel/register')({optional: ['es7']});
+
+// To ignore webpack custom loaders on server.
+config.webpackStylesExtensions.forEach(function(ext) {
+  require.extensions['.' + ext] = function() {};
+});
+
+require('./main');


### PR DESCRIPTION
This pull requests replaces `&&` that is not available in PowerShell and uses `;`. We should be just fine since we only `cd` before executing command and that is unlikely to fail. 

It also goes back with `cd..` since windows apparently do not support scoped commands `(...)`. It will have no effect on UNIX.