### PR TITLE
Use a separate bundle for vendor dependencies 

### DIFF
--- a/web/src/server/config.js
+++ b/web/src/server/config.js
@@ -12,7 +12,8 @@ nconf.env('__');
 var config = {
   assetsHashes: {
     appCss: isProduction ? hashFile.sync('build/app.css') : '',
-    appJs: isProduction ? hashFile.sync('build/app.js') : ''
+    appJs: isProduction ? hashFile.sync('build/app.js') : '',
+    vendorJs: isProduction ? hashFile.sync('build/vendor.js') : ''
   },
   appLocales: ['en', 'fr'],
   defaultLocale: 'en',

--- a/web/src/server/frontend/render.js
+++ b/web/src/server/frontend/render.js
@@ -76,6 +76,10 @@ function getPageHtml(renderProps, store, hostname, ua) {
     ? '/_assets/app.js?' + config.assetsHashes.appJs
     : `//${hostname}:${HOT_RELOAD_PORT}/build/app.js`;
 
+  const vendorScriptSrc = config.isProduction
+    ? '/_assets/vendor.js?' + config.assetsHashes.vendorJs
+    : `//${hostname}:${HOT_RELOAD_PORT}/build/vendor.js`;
+
   let scriptHtml = '';
 
   if (needIntlPolyfill) {
@@ -88,6 +92,7 @@ function getPageHtml(renderProps, store, hostname, ua) {
     <script>
       window.__INITIAL_STATE__ = ${JSON.stringify(store.getState())};
     </script>
+    <script src="${vendorScriptSrc}"></script>
     <script src="${appScriptSrc}"></script>
   `;
 

--- a/web/webpack/makeConfig.js
+++ b/web/webpack/makeConfig.js
@@ -51,6 +51,21 @@ export default function makeConfig(isDevelopment) {
         path.join(constants.SRC_DIR, 'client/main.js')
       ] : [
         path.join(constants.SRC_DIR, 'client/main.js')
+      ],
+      vendor: [
+        'immutable',
+        'invariant',
+        'react-document-title',
+        'react-dom',
+        'react-intl',
+        'react-pure-render',
+        'react-redux',
+        'react-router',
+        'react-textarea-autosize',
+        'react',
+        'redux-devtools',
+        'redux-devtools/lib/react',
+        'redux',
       ]
     },
     module: {
@@ -83,6 +98,7 @@ export default function makeConfig(isDevelopment) {
         })
       ];
       if (isDevelopment) plugins.push(
+        new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.HotModuleReplacementPlugin(),
         new webpack.NoErrorsPlugin()
@@ -94,6 +110,7 @@ export default function makeConfig(isDevelopment) {
           allChunks: true
         }),
         new NyanProgressPlugin(),
+        new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.optimize.UglifyJsPlugin({


### PR DESCRIPTION
This should speed up incremental builds during development at the cost of an extra http request during production.

NOTE! This needs to be tested. Currently npm gets stuck on installing `react-tools` so I can't actually run it. I will remote this note as soon as npm is able to successfully run.