### PR TITLE
Update babel-plugin-react-transform version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,7 +23,7 @@
     "babel": "^5.0.8",
     "babel-core": "^5.0.8",
     "babel-loader": "^5.0.0",
-    "babel-plugin-react-transform": "^1.0.5",
+    "babel-plugin-react-transform": "^1.1.1",
     "bluebird": "^2.9.9",
     "body-parser": "^1.12.4",
     "chai": "^3.0.0",


### PR DESCRIPTION
I was unable to start the web module and I was seeing many errors like the following:

```
ERROR in ./src/client/pages/auth.react.js
Module build failed: Error: ./web/src/client/pages/auth.react.js: babel-plugin-react-transform requires that you specify extras["react-transform"] in .babelrc or in your Babel Node API call options, and that it is an array.
```

I found that the config for this plugin had been updated in 196f0b14bb813b561d to reflect https://github.com/gaearon/babel-plugin-react-transform/releases/tag/v1.1.0, but the plugin itself had not.