### PR TITLE
Fixed Heroku deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   ],
   "private": true,
   "scripts": {
-    "preinstall": "(cd web && npm link ../common) && (cd native && npm link ../common)",
-    "postinstall": "(cd web && npm install) && (cd native && npm install)",
+    "postinstall": "./scripts/postInstall.sh",
     "start": "echo Please use `npm run web-start` to start a server",
     "web-start": "(cd web && npm start)",
     "web-start-dev": "(cd web && npm run start-dev)",
@@ -24,5 +23,10 @@
     "eslint": "^1.4.1",
     "eslint-plugin-react": "^3.3.2",
     "babel-eslint": "^4.1.2"
-  }
+  },
+  "cacheDirectories": [
+    "./web/node_modules",
+    "./node_modules",
+    "./common/node_modules"
+  ]
 }

--- a/scripts/postInstall.sh
+++ b/scripts/postInstall.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ "x$DYNO" != "x" ]; then
+
+  echo "Linking packages relatively for Heroku deployment"
+
+  cd web
+  mkdir -p ./node_modules/@este
+
+  (
+    cd ./node_modules/@este
+    rm -rf ./common
+
+    ln -s ../../../common ./common
+
+    cd ./common
+    npm install
+  )
+
+  npm install
+
+  echo "Building app"
+
+  npm run build
+
+  echo "Done."
+
+fi
+
+if [ "x$DYNO" == "x" ]; then
+
+  echo "Linking packages for non heroku environments"
+
+  (cd web && npm link ../common && npm install)
+  (cd native && npm link ../common && npm install)
+
+  echo "Done. Start your server with npm run web-start-dev"
+
+fi


### PR DESCRIPTION
Use relative symlink instead of npm link to survive move from /tmp to /app. Thanks to symlinks, it still works nicely with babel require hook :)

PS. Not windows friendly, but let's close issues one by one.

The build script also skips installing react-native dependencies as there's no point in having them.

CC: @steida, test app deployed to https://shielded-gorge-2924.herokuapp.com/ without any issues.