### PR TITLE
Add check for env before building webpack

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -28,7 +28,7 @@ gulp.task('env', () => {
   process.env.NODE_ENV = args.production ? 'production' : 'development';
 });
 
-gulp.task('build-webpack', webpackBuild);
+gulp.task('build-webpack', ['env'], webpackBuild);
 gulp.task('build', ['build-webpack']);
 
 gulp.task('eslint', () => {


### PR DESCRIPTION
Using a `gulp build -p` will not set properly the `NODE_ENV` to production, which implies that the `babel-loader` would use react-transform nonetheless. So we need to call env before.