### PR TITLE
Dynamically getting dev server IP address in config instead of using …

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "intl-messageformat": "^1.1.0",
     "intl-relativeformat": "^1.1.0",
     "invariant": "^2.1.0",
+    "ip": "^1.0.2",
     "isomorphic-fetch": "^2.1.1",
     "less": "^2.5.1",
     "less-loader": "^2.0.0",

--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -3,6 +3,7 @@ import autoprefixer from 'autoprefixer';
 import constants from './constants';
 import path from 'path';
 import webpack from 'webpack';
+import ip from 'ip';
 
 const devtools = process.env.CONTINUOUS_INTEGRATION
   ? 'inline-source-map'
@@ -18,6 +19,8 @@ const loaders = {
   'sass': '!sass-loader?indentedSyntax',
   'styl': '!stylus-loader'
 };
+
+const serverIp = ip.address();
 
 export default function makeConfig(isDevelopment) {
 
@@ -42,7 +45,7 @@ export default function makeConfig(isDevelopment) {
     devtool: isDevelopment ? devtools : '',
     entry: {
       app: isDevelopment ? [
-        `webpack-hot-middleware/client?path=http://localhost:${constants.HOT_RELOAD_PORT}/__webpack_hmr`,
+        `webpack-hot-middleware/client?path=http://${serverIp}:${constants.HOT_RELOAD_PORT}/__webpack_hmr`,
         path.join(constants.SRC_DIR, 'client/main.js')
       ] : [
         path.join(constants.SRC_DIR, 'client/main.js')
@@ -83,7 +86,7 @@ export default function makeConfig(isDevelopment) {
       path: constants.BUILD_DIR,
       filename: '[name].js',
       chunkFilename: '[name]-[chunkhash].js',
-      publicPath: `http://localhost:${constants.HOT_RELOAD_PORT}/build/`
+      publicPath: `http://${serverIp}:${constants.HOT_RELOAD_PORT}/build/`
     } : {
       path: constants.BUILD_DIR,
       filename: '[name].js',


### PR DESCRIPTION
Currently in maskConfig.js the hostname is hardcoded as "localhost" which prevents hot module replacement from working on devices that are pointed at the IP address of the machine serving the app.

This pull request switches out the hardcoded value for the hostname of the dev machine for its local network IP, meaning that HMR works on devices.