### PR TITLE
Fix Mocha and Mocha watch error handling

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -3,8 +3,7 @@ import bg from 'gulp-bg';
 import eslint from 'gulp-eslint';
 import fs from 'fs';
 import gulp from 'gulp';
-import gutil from 'gulp-util';
-import mocha from 'gulp-mocha';
+import mochaRunCreator from './test/mochaRunCreator';
 import os from 'os';
 import path from 'path';
 import runSequence from 'run-sequence';
@@ -43,19 +42,15 @@ gulp.task('eslint-ci', () => {
 });
 
 gulp.task('mocha', () => {
-  // read: false, not to load file contents
-  gulp.src('src/**/__test__/**/*.js', {read: false})
-    .pipe(mocha({
-      require: ['./test/mochaSetup.js'],
-      reporter: 'spec'
-    }))
-    // .on('error', process.exit.bind(process, 1));
-    .on('error', gutil.log);
+  mochaRunCreator('process')();
 });
 
 // Continuous test running
 gulp.task('mocha-watch', () => {
-  gulp.watch(['test/**/**', 'src/client/**', 'src/common/**'], ['mocha']);
+  gulp.watch(
+    ['test/**/**', 'src/client/**', 'src/common/**'],
+    mochaRunCreator('log')
+  );
 });
 
 gulp.task('test', done => {

--- a/test/mochaRunCreator.js
+++ b/test/mochaRunCreator.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-undef */
+
+import gulp from 'gulp';
+import gutil from 'gulp-util';
+import mocha from 'gulp-mocha';
+
+function reportError(errorReporter) {
+  return errorReporter === 'process' ? process.exit.bind(process, 1) : gutil.log
+}
+
+export default function mochaRunCreator(errorReporter = 'process') {
+  return () => {
+    // read: false, not to load file contents
+    gulp.src('src/**/__test__/**/*.js', {read: false})
+      .pipe(mocha({
+        require: ['./test/mochaSetup.js'],
+        reporter: 'spec'
+      }))
+      .on('error', reportError(errorReporter));
+  }
+}


### PR DESCRIPTION
HI problem is that: 

`gulp mocha` on failed test needs to return status code 1
`gulp mocha-watch` on failed test needs to print output to log

This PR is taken care of this