### PR TITLE
Report unhandled Promise rejections in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "serialize-javascript": "^1.1.2",
     "serve-favicon": "^2.2.0",
     "sinon": "^1.17.2",
+    "sinon-as-promised": "^4.0.0",
     "sinon-chai": "^2.8.0",
     "style-loader": "^0.13.0",
     "stylus-loader": "^1.0.0",

--- a/src/browser/auth/__test__/Login.spec.js
+++ b/src/browser/auth/__test__/Login.spec.js
@@ -22,26 +22,28 @@ describe('Login component', () => {
     }
   };
 
-  const loginAction = sinon.stub().resolves({});
-  const replaceState = sinon.spy();
+  let sandbox, loginComponent, inputs, button, loginAction, replaceState, form;
 
-  const data = {
-    actions: {
-      login: loginAction
-    },
-    history: {
-      replaceState
-    },
-    location: {},
-    msg: msg,
-    auth: {form: new Form()}
+  function componentProps() {
+    return {
+      actions: {
+        login: loginAction
+      },
+      history: {
+        replaceState
+      },
+      location: {},
+      msg: msg,
+      auth: {form: new Form()}
+    };
   };
-
-  let sandbox, loginComponent, inputs, button;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    loginComponent = TestUtils.renderIntoDocument(<Login {...data} />);
+    loginAction = sandbox.stub().resolves({});
+    replaceState = sandbox.spy();
+
+    loginComponent = TestUtils.renderIntoDocument(<Login {...componentProps()} />);
     inputs = TestUtils.scryRenderedDOMComponentsWithTag(loginComponent, 'input');
     button = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'button');
     form = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'form');
@@ -56,14 +58,19 @@ describe('Login component', () => {
     expect(button).to.not.equal(null);
   });
 
-  it('should fire login action and redirect', (done) => {
+  it('should fire login action on form submit', () => {
     TestUtils.Simulate.submit(form);
 
     expect(loginAction.calledOnce).to.be.true;
+  });
+
+  it('should redirect to home on successful login', done => {
+    TestUtils.Simulate.submit(form);
+
     loginAction().then(() => {
       expect(replaceState.calledOnce).to.be.true;
       expect(replaceState.calledWithExactly(null, '/')).to.be.true;
       done();
-    })
+    });
   });
 });

--- a/src/browser/auth/__test__/Login.spec.js
+++ b/src/browser/auth/__test__/Login.spec.js
@@ -1,4 +1,3 @@
-import * as actions from '../../../common/auth/actions';
 import Form from '../../../common/auth/form';
 import Login from '../Login.react';
 
@@ -23,21 +22,29 @@ describe('Login component', () => {
     }
   };
 
+  const loginAction = sinon.stub().resolves({});
+  const replaceState = sinon.spy();
+
   const data = {
-    actions: actions,
-    history: {},
+    actions: {
+      login: loginAction
+    },
+    history: {
+      replaceState
+    },
     location: {},
     msg: msg,
     auth: {form: new Form()}
   };
 
-  let sandbox, loginForm, inputs, button;
+  let sandbox, loginComponent, inputs, button;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
-    loginForm = TestUtils.renderIntoDocument(<Login {...data} />);
-    inputs = TestUtils.scryRenderedDOMComponentsWithTag(loginForm, 'input');
-    button = TestUtils.findRenderedDOMComponentWithTag(loginForm, 'button');
+    loginComponent = TestUtils.renderIntoDocument(<Login {...data} />);
+    inputs = TestUtils.scryRenderedDOMComponentsWithTag(loginComponent, 'input');
+    button = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'button');
+    form = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'form');
   });
 
   afterEach(() => {
@@ -47,5 +54,16 @@ describe('Login component', () => {
   it('should generate a login form', () => {
     expect(inputs.length).to.equal(2);
     expect(button).to.not.equal(null);
+  });
+
+  it('should fire login action and redirect', (done) => {
+    TestUtils.Simulate.submit(form);
+
+    expect(loginAction.calledOnce).to.be.true;
+    loginAction().then(() => {
+      expect(replaceState.calledOnce).to.be.true;
+      expect(replaceState.calledWithExactly(null, '/')).to.be.true;
+      done();
+    })
   });
 });

--- a/test/mochaSetup.js
+++ b/test/mochaSetup.js
@@ -1,3 +1,5 @@
+/* global global */
+
 require('babel/register')({
   stage: 0
 });
@@ -21,10 +23,10 @@ propagateToGlobal(win);
 
 // From mocha-jsdom https://github.com/rstacruz/mocha-jsdom/blob/master/index.js#L80
 function propagateToGlobal(window) {
-  for (let key in window) {
-    if (!window.hasOwnProperty(key)) continue
-    if (key in global) continue
+  for (const key in window) {
+    if (!window.hasOwnProperty(key)) continue;
+    if (key in global) continue;
 
-    global[key] = window[key]
+    global[key] = window[key];
   };
 };

--- a/test/mochaTestHelper.js
+++ b/test/mochaTestHelper.js
@@ -1,11 +1,17 @@
+import Bluebird from 'bluebird';
 import chai, {assert, expect} from 'chai';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
 import sinon from 'sinon';
+import sinonAsPromised from 'sinon-as-promised';
 import sinonChai from 'sinon-chai';
+import TestUtils from 'react-addons-test-utils';
 
 chai.should();
 chai.use(sinonChai);
+
+// Use Bluebird Promises inside of sinon stubs.
+// Bluebird has better error reporting for unhandled Promises.
+sinonAsPromised(Bluebird);
 
 export {
   assert,


### PR DESCRIPTION
And add one example usage.

Without this you never know if there was an error inside of a `then` in tests.