### PR TITLE
Downgrade ESLint due to problem with new (Record({}))

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cors": "^2.6.0",
     "css-loader": "^0.22.0",
     "del": "^2.1.0",
-    "eslint": "^1.9.0",
+    "eslint": "1.9.0",
     "eslint-plugin-import": "^0.10.0",
     "eslint-plugin-react": "^3.8.0",
     "express": "^4.13.3",


### PR DESCRIPTION
ESLint issue: https://github.com/eslint/eslint/issues/4508

Problem is with calling new with parens following

```js
const foo = new (Foo({dummy: true}))