### PR TITLE
Fix assets paths when server started from different location than root of project

### DIFF
--- a/src/server/frontend/assets.js
+++ b/src/server/frontend/assets.js
@@ -11,6 +11,9 @@ export default async function getAppAssetFilenamesAsync() { // eslint-disable-li
   if (!config.isProduction) return DEFAULT;
 
   try {
+    // We need to find assets with hashes in build directory
+    // so we use current directory of assets.js and create absolute location
+    // of build directory without knowing from which location process was started
     const buildDir = path.resolve(__dirname, '..', '..', '..', 'build');
     const buildDirFiles = await fs.readdirAsync(buildDir);
 

--- a/src/server/frontend/assets.js
+++ b/src/server/frontend/assets.js
@@ -1,5 +1,6 @@
 import config from '../config';
 import fs from '../lib/fs';
+import path from 'path';
 
 const DEFAULT = {js: 'app.js', css: 'app.css'};
 
@@ -10,7 +11,8 @@ export default async function getAppAssetFilenamesAsync() { // eslint-disable-li
   if (!config.isProduction) return DEFAULT;
 
   try {
-    const buildDirFiles = await fs.readdirAsync('build');
+    const buildDir = path.resolve(__dirname, '..', '..', '..', 'build');
+    const buildDirFiles = await fs.readdirAsync(buildDir);
 
     return {
       js: buildDirFiles.find(filename => APP_JS_PATTERN.test(filename)),


### PR DESCRIPTION
When you are starting Este by Passenger you are setting `passenger_startup_file` and then you are in different directory then expected.

By using `__dirname` you will get exact location of `assets.js` and then you can easily traverse to build directory