### PR TITLE
Use stateTransformer instead of deprecated transformer in redux-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.0.5",
     "redux": "^3.0.4",
-    "redux-logger": "^2.0.1",
+    "redux-logger": "^2.1.1",
     "redux-promise-middleware": "2.2.3",
     "redux-storage": "^1.2.4",
     "regenerator": "^0.8.42",

--- a/src/common/configureStore.js
+++ b/src/common/configureStore.js
@@ -43,7 +43,7 @@ export default function configureStore({deps, engine, initialState}) {
   if (BROWSER_DEVELOPMENT) {
     const logger = createLogger({
       collapsed: true,
-      transformer: stateToJS
+      stateTransformer: stateToJS
     });
     // Logger must be the last middleware in chain.
     middleware = [...middleware, logger];


### PR DESCRIPTION
The transformer option of redux-logger is deprecated in the latest minor version https://github.com/fcomb/redux-logger/releases/tag/2.1.1