### PR TITLE
stop middleware sequence if no action

### DIFF
--- a/src/common/lib/injectDependencies.js
+++ b/src/common/lib/injectDependencies.js
@@ -9,6 +9,7 @@ export default function injectDependencies(statics, dynamic = {}) {
     Object.keys(dynamic).forEach(key => {
       dependencies[key] = dynamic[key](getState());
     });
-    return dispatch(action({...dependencies, getState, dispatch}));
+    const nextAction = action({...dependencies, getState, dispatch});
+    return nextAction && dispatch(nextAction);
   };
 }


### PR DESCRIPTION
After injecting dependencies into action we can encounter situation, in which for example fetchng of data is not needed, because it's in state. We can then return with no action, but injectDepenedencies is not stoping this case and is sending undefined to next middleware, which i believe is problem:

```
function fetchUsers() {
  return ({getState}) => {
    if(getState().getIn(['users'])) return; //users are loaded, not need to propagate action to other middlewares
    ...
  }
}
```

redux-promise-middleware will throw with exception that action must be object with type defined