### PR TITLE
Ensure webpack receives process.env.WEB_ADDR

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -95,6 +95,7 @@ export default function makeConfig(isDevelopment) {
         new webpack.DefinePlugin({
           'process.env': {
             NODE_ENV: JSON.stringify(isDevelopment ? 'development' : 'production'),
+            WEB_ADDR: JSON.stringify(process.env.WEB_ADDR || ''),
             IS_BROWSER: true
           }
         })


### PR DESCRIPTION
- Fixes issue where `process.env.WEB_ADDR` was only available on `server` rendering platform.

So now when you run:
```
WEB_ADDR=https://production-appName.herokuapp.com gulp 
```

It will properly be availble for mobile and browser as `process.env.WEB_ADDR`