### PR TITLE
Upgrade to React Router 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-native-side-menu": "^0.17.0",
     "react-pure-render": "^1.0.1",
     "react-redux": "^3.0.0",
-    "react-router": "^1.0.2",
+    "react-router": "^2.0.0-rc5",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.0.5",

--- a/src/browser/auth/Login.react.js
+++ b/src/browser/auth/Login.react.js
@@ -9,9 +9,12 @@ export default class Login extends Component {
   static propTypes = {
     actions: PropTypes.object.isRequired,
     auth: PropTypes.object.isRequired,
-    history: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     msg: PropTypes.object.isRequired
+  };
+
+  static contextTypes = {
+    router: PropTypes.object.isRequired
   };
 
   constructor(props) {
@@ -33,11 +36,13 @@ export default class Login extends Component {
 
   // TODO: Use redux-react-router.
   redirectAfterLogin() {
-    const {history, location} = this.props;
+    const {location} = this.props;
+    const {router} = this.context;
+
     if (location.state && location.state.nextPathname)
-      history.replaceState(null, location.state.nextPathname);
+      router.replace(location.state.nextPathname);
     else
-      history.replaceState(null, '/');
+      router.replace('/');
   }
 
   render() {

--- a/src/browser/auth/__test__/Login.spec.js
+++ b/src/browser/auth/__test__/Login.spec.js
@@ -10,6 +10,22 @@ import {
   TestUtils
 } from '../../../../test/mochaTestHelper';
 
+function provideRouterContext(Component, router) {
+  return class extends Component {
+    static childContextTypes = {
+      router: React.PropTypes.object
+    };
+
+    getChildContext() {
+      return {router};
+    }
+
+    render() {
+      return <Component {...this.props} />;
+    }
+  };
+}
+
 describe('Login component', () => {
   const msg = {
     auth: {
@@ -29,16 +45,13 @@ describe('Login component', () => {
   let inputs;
   let loginAction;
   let loginComponent;
-  let replaceState;
+  let replace;
   let sandbox;
 
   function componentProps() {
     return {
       actions: {
         login: loginAction
-      },
-      history: {
-        replaceState
       },
       location: {},
       msg: msg,
@@ -53,9 +66,10 @@ describe('Login component', () => {
         promise: Promise.resolve({})
       }
     });
-    replaceState = sandbox.spy();
+    replace = sandbox.spy();
 
-    loginComponent = TestUtils.renderIntoDocument(<Login {...componentProps()} />);
+    const Component = provideRouterContext(Login, {replace});
+    loginComponent = TestUtils.renderIntoDocument(<Component {...componentProps()} />);
     inputs = TestUtils.scryRenderedDOMComponentsWithTag(loginComponent, 'input');
     button = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'button');
     form = TestUtils.findRenderedDOMComponentWithTag(loginComponent, 'form');
@@ -81,7 +95,7 @@ describe('Login component', () => {
 
     await loginAction();
 
-    expect(replaceState.calledOnce).to.be.true;
-    expect(replaceState.calledWithExactly(null, '/')).to.be.true;
+    expect(replace.calledOnce).to.be.true;
+    expect(replace.calledWithExactly('/')).to.be.true;
   });
 });

--- a/src/browser/createRoutes.js
+++ b/src/browser/createRoutes.js
@@ -11,10 +11,13 @@ import {IndexRoute, Route} from 'react-router';
 
 export default function createRoutes(getState) {
 
-  const requireAuth = (nextState, replaceState) => {
+  const requireAuth = (nextState, replace) => {
     const loggedInUser = getState().users.viewer;
     if (!loggedInUser) {
-      replaceState({nextPathname: nextState.location.pathname}, '/login');
+      replace({
+        pathname: '/login',
+        state: {nextPathname: nextState.location.pathname}
+      });
     }
   };
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -3,11 +3,11 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Router from 'react-router';
 import configureStore from '../common/configureStore';
-import createBrowserHistory from 'history/lib/createBrowserHistory';
 import createEngine from 'redux-storage/engines/localStorage';
 import createRoutes from './createRoutes';
 import {IntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
+import {browserHistory} from 'react-router';
 
 // TODO: Add app storage example.
 // import storage from 'redux-storage';
@@ -24,7 +24,7 @@ const routes = createRoutes(store.getState);
 ReactDOM.render(
   <Provider store={store}>
     <IntlProvider>
-      <Router history={createBrowserHistory()}>
+      <Router history={browserHistory}>
         {routes}
       </Router>
     </IntlProvider>

--- a/src/server/frontend/render.js
+++ b/src/server/frontend/render.js
@@ -9,7 +9,7 @@ import createRoutes from '../../browser/createRoutes';
 import serialize from 'serialize-javascript';
 import {IntlProvider} from 'react-intl';
 import {Provider} from 'react-redux';
-import {RoutingContext, match} from 'react-router';
+import {RouterContext, match} from 'react-router';
 import {createMemoryHistory} from 'history';
 
 const fetchComponentDataAsync = async (dispatch, renderProps) => {
@@ -28,7 +28,7 @@ const getAppHtml = (store, renderProps) => {
   return ReactDOMServer.renderToString(
     <Provider store={store}>
       <IntlProvider>
-        <RoutingContext {...renderProps} />
+        <RouterContext {...renderProps} />
       </IntlProvider>
     </Provider>
   );


### PR DESCRIPTION
No warnings, no errors.

https://github.com/rackt/react-router/blob/master/upgrade-guides/v2.0.0.md

I thought that we could get rid of the RouteHandler and using `cloneElement`, but it turned out that the `<Router render={} />` which I wanted to use for this is for entirely different use case and does not help us.