### PR TITLE
Fix errorHandler arity

### DIFF
--- a/src/server/lib/errorHandler.js
+++ b/src/server/lib/errorHandler.js
@@ -1,6 +1,6 @@
 import config from '../config';
 
-export default function errorHandler(err, req, res) {
+export default function errorHandler(err, req, res, next) { // eslint-disable-line no-unused-vars
   const errorDetails = err.stack || err;
 
   console.error('Yay', errorDetails);


### PR DESCRIPTION
According to [docs](http://expressjs.com/en/guide/error-handling.html): *"Define error-handling middleware functions in the same way as other middleware functions, except error-handling functions have four arguments instead of three: (err, req, res, next)."*