### PR TITLE
Issue #715 fix. Changing webpacks test for fonts to allow fonts path …

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -62,7 +62,7 @@ export default function makeConfig(isDevelopment) {
         test: /favicon\.ico$/
       }, {
         loader: 'url-loader?limit=100000',
-        test: /\.(eot|ttf|woff|woff2)$/
+        test: /\.(ttf|eot|svg|woff(2)?)(\?[a-z0-9]+)?$/,
       }, {
         test: /\.js$/,
         exclude: /node_modules/,


### PR DESCRIPTION
webpacks test for fonts to allow path with parameters, ie. 'url('../fonts/icomoon.eot?z54p55')'.

http://stackoverflow.com/questions/31180570/webpack-can-not-load-font-file-unexpected-token