### PR TITLE
Safer DI middleware

### DIFF
--- a/src/common/app/actions.js
+++ b/src/common/app/actions.js
@@ -3,19 +3,19 @@ import * as firebaseAction from '../lib/redux-firebase/actions';
 export const ON_APP_COMPONENT_DID_MOUNT = 'ON_APP_COMPONENT_DID_MOUNT';
 
 export function onAppComponentDidMount() {
-  // Who injected firebase and store? Check configureStore.js injectMiddleware.
-  return ({firebase, store}) => {
+  // Who injected firebase and dispatch? Check configureStore.js injectMiddleware.
+  return ({firebase, dispatch}) => {
 
     // Firebase has two methods to get user auth.
     //  - getAuth is sync, because it uses localStorage.
     //  - onAuth is async, because it monitors current auth from server.
 
     // Sync is nice, because it updates app state immediately.
-    store.dispatch(firebaseAction.onAuth(firebase.getAuth()));
+    dispatch(firebaseAction.onAuth(firebase.getAuth()));
 
     // Async handling of login / logout.
     firebase.onAuth(authData => {
-      store.dispatch(firebaseAction.onAuth(authData));
+      dispatch(firebaseAction.onAuth(authData));
     });
 
     return {

--- a/src/common/configureStore.js
+++ b/src/common/configureStore.js
@@ -20,9 +20,9 @@ export default function configureStore({deps, initialState}) {
 
   // Este dependency injection middleware. So simple that we don't need a lib.
   // It's like mixed redux-thunk and redux-inject.
-  const injectMiddleware = deps => store => next => action =>
+  const injectMiddleware = deps => ({dispatch, getState}) => next => action =>
     next(typeof action === 'function'
-      ? action({...deps, store})
+      ? action({...deps, dispatch, getState})
       : action
     );
 


### PR DESCRIPTION
Actions do not need access to `subscribe` or `replaceReducer`.

I think that actions usually need to know current state to compute next step. So current `state` is directly passed. (Small question: Would `getState` be better/safer?)