### PR TITLE
Load initial state from data attribute instead of inline code

### DIFF
--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -15,7 +15,7 @@ import { routerMiddleware, syncHistoryWithStore } from 'react-router-redux';
 window.Promise = Bluebird;
 
 const app = document.getElementById('app');
-const initialState = window.__INITIAL_STATE__;
+const initialState = JSON.parse(app.getAttribute('data-initial-state'));
 const store = configureStore({
   initialState,
   platformMiddleware: [routerMiddleware(browserHistory)]

--- a/src/server/frontend/Html.react.js
+++ b/src/server/frontend/Html.react.js
@@ -4,15 +4,15 @@ export default class Html extends Component {
 
   static propTypes = {
     appCssFilename: PropTypes.string,
-    bodyHtml: PropTypes.string.isRequired,
+    children: PropTypes.array.isRequired,
     googleAnalyticsId: PropTypes.string.isRequired,
     helmet: PropTypes.object.isRequired,
-    isProduction: PropTypes.bool.isRequired,
+    isProduction: PropTypes.bool.isRequired
   };
 
   render() {
     const {
-      appCssFilename, bodyHtml, googleAnalyticsId, isProduction, helmet
+      appCssFilename, googleAnalyticsId, isProduction, helmet, children
     } = this.props;
 
     const linkStyles = appCssFilename &&
@@ -45,7 +45,9 @@ ga('create', '${googleAnalyticsId}', 'auto'); ga('send', 'pageview');` }}
           {linkStyles}
           {analytics}
         </head>
-        <body dangerouslySetInnerHTML={{ __html: bodyHtml }} />
+        <body>
+          {children}
+        </body>
       </html>
     );
   }

--- a/src/server/frontend/render.js
+++ b/src/server/frontend/render.js
@@ -41,23 +41,22 @@ const getAppContainer = (state, store, renderProps) =>
     </Provider>
   </div>;
 
-const getScripts = (state, headers, hostname, appJsFilename) =>
+const getScripts = (appJsFilename) =>
   // Note how we use cdn.polyfill.io, en is default, but can be changed later.
   <div>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en"></script>
     <script src={appJsFilename}></script>
   </div>;
 
-const renderPage = (store, renderProps, req) => {
+const renderPage = (store, renderProps) => {
   const state = store.getState();
-  const { headers, hostname } = req;
   const appContainer = getAppContainer(state, store, renderProps);
   const helmet = Helmet.rewind();
   const {
     styles: { app: appCssFilename },
     javascript: { app: appJsFilename }
   } = webpackIsomorphicTools.assets();
-  const scripts = getScripts(state, headers, hostname, appJsFilename);
+  const scripts = getScripts(appJsFilename);
   if (!config.isProduction) {
     webpackIsomorphicTools.refresh();
   }


### PR DESCRIPTION
Motivation is to enable stricter settings for **Content Security Policy**. See this article for details about CSP: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful

I used `JSON.stringify` instead of `serialize-javascript` for these reasons:
- I believe it is safe to use `JSON.stringify` for HTML attributes content (`<foo bar={JSON.stringify({"haxorXSS":"</script>"})}/>` becomes `<foo bar="{&quot;haxorXSS&quot;:&quot;&lt;/script&gt;&quot;}"/>`).
- Output of `serialize-javascript` is incompatible with JSON, if the input contains functions or regexps. And I can't use `eval()` for unserializing, if I mean it with the Content Security Policy.