### PR TITLE
babel loader - excluded only application modules

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -64,7 +64,7 @@ export default function makeConfig(isDevelopment) {
         test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9]+)?$/
       }, {
         test: /\.js$/,
-        exclude: /node_modules/,
+        exclude: constants.NODE_MODULES_DIR,
         loader: 'babel',
         query: {
           cacheDirectory: true,


### PR DESCRIPTION
When este application is placed inside `node_modules` directory the code transpilation does not work. All files are ignored because application's base directory path contains `node_modules` string.

I have encountered this problem while trying to pack and install application from file using npm (`npm pack`, `npm install <my_package>`.