### PR TITLE
Take care of req.query in render.js

### DIFF
--- a/src/server/frontend/render.js
+++ b/src/server/frontend/render.js
@@ -107,7 +107,7 @@ export default function render(req, res, next) {
       host: `${protocol}://${req.headers.host}`
     }
   };
-  const memoryHistory = createMemoryHistory(req.path);
+  const memoryHistory = createMemoryHistory(req.originalUrl);
   const store = configureStore({
     initialState,
     platformMiddleware: [routerMiddleware(memoryHistory)]


### PR DESCRIPTION
Solving issue #792. Use also ```req.query``` when the page is generated on the server.