### PR TITLE
Fixes #752: Fix babel-plugin-transform-react-constant-elements hoisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-react-intl": "^2.1.1",
     "babel-plugin-react-transform": "^2.0.0",
-    "babel-plugin-transform-react-constant-elements": "^6.3.13",
+    "babel-plugin-transform-react-constant-elements": "^6.5.0",
     "babel-plugin-transform-react-inline-elements": "^6.3.13",
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-polyfill": "^6.5.0",

--- a/src/native/app/App.react.js
+++ b/src/native/app/App.react.js
@@ -62,15 +62,15 @@ class App extends Component {
 
   renderScene(route) {
     const { toggleSideMenu } = this.props;
-    return (
-      <View style={[styles.sceneView, route.style]}>
-        <Header
-          title={this.getTitle(route)}
-          toggleSideMenu={toggleSideMenu}
-        />
-        <route.Page />
-      </View>
-    );
+    // Workaround not using JSX per Este issue
+    // See: https://github.com/este/este/issues/752
+    const childHeader = React.createElement(Header, {
+      title: this.getTitle(route),
+      toggleSideMenu: this.toggleSideMenu
+    });
+    const childPage = React.createElement(route.Page);
+    return React.createElement(View, { style: [styles.sceneView, route.style] },
+      childHeader, childPage);
   }
 
   render() {


### PR DESCRIPTION
See issue:  https://github.com/este/este/issues/752

When bundled for Release mode on iOS, babel-transform-react-constant-elements hoists the variable "route" to a higher scope under the false assumption that "route" is a constant variable. The JSX does not get transpiled 100% correctly resulting in a missing variable.