### PR TITLE
remove gulp-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "gulp-eslint": "2.0.0",
     "gulp-if": "^2.0.0",
     "gulp-mocha": "^2.1.3",
-    "gulp-shell": "^0.5.0",
     "gulp-util": "^3.0.7",
     "immutable": "^3.6.4",
     "intl": "^1.0.0",


### PR DESCRIPTION
gulp-shell is blacklisted, and it's faulty & half-abandoned plugin. For example, it fails if the process produces too much output to the console, probably because exhausting some limits on buffers.

Here I summarized a few alternatives:

http://stackoverflow.com/questions/37187069/how-to-easily-run-system-shell-task-command-in-gulp

I've tested this on windows, (since this was the reason for using `gulp-shell` in the first place) and at least `server-nodemon` works fine.