### PR TITLE
Fix react-fields onChange handler for react-select

### DIFF
--- a/src/common/lib/redux-fields/fields.js
+++ b/src/common/lib/redux-fields/fields.js
@@ -62,7 +62,10 @@ export default function fields(Wrapped, options) {
         }
       } : {
         name: field,
-        onChange: ({ target: { type, checked, value } }) => {
+        onChange: (event) => {
+          // React-select is not passing an event but the target directly
+          const target = event.target || event;
+          const { type, checked, value } = target;
           const isCheckbox = type && type.toLowerCase() === 'checkbox';
           onChange(field, isCheckbox ? checked : value);
         }


### PR DESCRIPTION
@steida I like your implementation of `redux-fields`, but I encountered a small issue while using it together with `react-select`.
The implementation of `redux-select` sends the target directly to the `onChange` handler, but `redux-fields` is expecting that the target is wrapped in an event object first.
I prepared a small fix for it.