### PR TITLE
Use gulp-shell instead of gulp-bg in server-nodemon

### DIFF
--- a/gulp/server-nodemon.js
+++ b/gulp/server-nodemon.js
@@ -1,13 +1,10 @@
-import bg from 'gulp-bg';
 import gulp from 'gulp';
 import path from 'path';
+import shell from 'gulp-shell';
 
 gulp.task(
   'server-nodemon',
-  bg(
-    path.normalize('node_modules/.bin/nodemon'),
-    '--ignore',
-    'webpack-assets.json',
-    path.normalize('src/server')
+  shell.task(
+    path.normalize('node_modules/.bin/nodemon --ignore webpack-assets.json src/js/server')
   )
 );

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-if": "^2.0.0",
     "gulp-mocha": "^2.1.3",
     "gulp-real-favicon": "^0.2.1",
+    "gulp-shell": "^0.5.2",
     "gulp-util": "^3.0.7",
     "immutable": "^3.6.4",
     "intl": "^1.0.0",


### PR DESCRIPTION
Solving issue #920, problems with `gulp-bg` on Windows.