### PR TITLE
Use long month for FormattedDate using a temporary patch for Intl.js

### DIFF
--- a/src/browser/intl/IntlPage.react.js
+++ b/src/browser/intl/IntlPage.react.js
@@ -54,7 +54,10 @@ class IntlPage extends Component {
         <p>
           <FormattedDate
             value={Date.now()}
-            {...{ day: 'numeric', month: 'short', year: 'numeric' }}
+            day="numeric"
+            month="long"
+            year="numeric"
+            formatMatcher="basic" // while this bug remains in react-intl: https://github.com/andyearnshaw/Intl.js/issues/179
           />
         </p>
         <p>


### PR DESCRIPTION
Following https://github.com/este/este/commit/b51807b624c9a72af93e325a31fa259f91f01a24

See [react-intl's API](https://github.com/yahoo/react-intl/wiki/API#date-formatting-apis)