### PR TITLE
Fixed logging of unhandled mocha errors

### DIFF
--- a/gulp/mocha-file.js
+++ b/gulp/mocha-file.js
@@ -5,5 +5,5 @@ import path from 'path';
 
 gulp.task('mocha-file', () => {
   // Example: gulp mocha-file --file src/common/todos/__test__/actions.js
-  mochaRunCreator('process')({ path: path.join(__dirname, args.file) });
+  mochaRunCreator('exit')({ path: path.join(__dirname, `../${args.file}`) });
 });

--- a/gulp/mocha.js
+++ b/gulp/mocha.js
@@ -2,5 +2,5 @@ import gulp from 'gulp';
 import mochaRunCreator from '../test/mochaRunCreator';
 
 gulp.task('mocha', () => {
-  mochaRunCreator('process')();
+  mochaRunCreator('exit')();
 });


### PR DESCRIPTION
Errors in mocha tests that were not handled and logged by mocha itself (thrown inside `it()`) just quietly terminated the process without any way to know what happened. Plus there was no need to log test errors again with gulp because mocha does it pretty well.

The fix takes in count the flow of the default `mocha` task, plus `mocha-file` and `mocha-watch`
