### PR TITLE
Fix for incorrect initialization of FBSDKPackage for Android

### DIFF
--- a/android/app/src/main/java/com/este/MainActivity.java
+++ b/android/app/src/main/java/com/este/MainActivity.java
@@ -1,5 +1,6 @@
 package com.este;
 
+import android.content.Intent;
 import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
@@ -11,5 +12,11 @@ public class MainActivity extends ReactActivity {
     @Override
     protected String getMainComponentName() {
         return "Este";
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        MainApplication.getCallbackManager().onActivityResult(requestCode, resultCode, data);
     }
 }

--- a/android/app/src/main/java/com/este/MainApplication.java
+++ b/android/app/src/main/java/com/este/MainApplication.java
@@ -6,6 +6,8 @@ import android.util.Log;
 import com.facebook.react.ReactApplication;
 import com.oblador.vectoricons.VectorIconsPackage;
 import io.fixd.rctlocale.RCTLocalePackage;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookSdk;
 import com.facebook.reactnative.androidsdk.FBSDKPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
@@ -16,6 +18,20 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
+
+  private static CallbackManager mCallbackManager = CallbackManager.Factory.create();
+
+  protected static CallbackManager getCallbackManager() {
+    return mCallbackManager;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+    FacebookSdk.sdkInitialize(getApplicationContext());
+    // If you want to use AppEventsLogger to log events.
+    //AppEventsLogger.activateApp(this);
+  }
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -29,7 +45,7 @@ public class MainApplication extends Application implements ReactApplication {
           new MainReactPackage(),
             new VectorIconsPackage(),
             new RCTLocalePackage(),
-            new FBSDKPackage()
+            new FBSDKPackage(mCallbackManager)
       );
     }
   };


### PR DESCRIPTION
There's a bug in the `MainApplication.java` file of the android project on line 32 (you will see the following if you try to run `react-native run-android`):
```
...\este-app\android\app\src\main\java\com\este\MainApplication.java:32: error: constructor FBSDKPackage in class FBSDKPackage cannot be applied to given types;
            new FBSDKPackage()
            ^
  required: CallbackManager
  found: no arguments
  reason: actual and formal argument lists differ in length
1 error
:app:compileDebugJavaWithJavac FAILED

FAILURE: Build failed with an exception.
```

I've modified the file according to the readme for FBSDK https://github.com/facebook/react-native-fbsdk so this should be fixed now.