### PR TITLE
Redux DevTools Extension support

### DIFF
--- a/src/common/configureStore.js
+++ b/src/common/configureStore.js
@@ -1,6 +1,6 @@
 import configureReducer from './configureReducer';
 import configureMiddleware from './configureMiddleware';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
 
 export default function configureStore(options) {
   const {
@@ -24,7 +24,11 @@ export default function configureStore(options) {
   const store = createStore(
     reducer,
     initialState,
-    applyMiddleware(...middleware)
+    compose(
+      applyMiddleware(...middleware),
+      typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ?
+        window.devToolsExtension() : f => f
+    )
   );
 
   // Enable hot reload where available.


### PR DESCRIPTION
Someone may want to use Redux DevTools Extension for Chrome/Firefox. It worked some time ago but now it doesn't. This is simple fix according to https://github.com/zalmoxisus/redux-devtools-extension#22-advanced-store-setup

I found this extension very handy for inspecting the state and watching changes in time.