### PR TITLE
replace 'shortid' with 'uuid' / 'react-native-uuid'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@
 - [bluebird](https://github.com/petkaantonov/bluebird) Because it's better than native implementation.
 - [AVA](https://github.com/avajs/ava) Futuristic JavaScript test runner.
 - SASS or plain CSS with [autoprefixer](https://github.com/postcss/autoprefixer)
-- [shortid](https://github.com/dylang/shortid) Short id generator. Url-friendly. Non-predictable.
+- [uuid](https://github.com/defunctzombie/node-uuid) Generate RFC-compliant UUIDs in JavaScript.
+- [react-native-uuid](https://github.com/eugenehp/react-native-uuid) node-uuid for react-native.
 - [gulp](http://gulpjs.com/) Aren't NPM scripts better? [No](https://twitter.com/jaffathecake/status/700320306053935104).
 - [raven-js](https://github.com/getsentry/raven-js) Crash reporting client for [Sentry](https://getsentry.com).
 - [gulp-real-favicon](https://www.npmjs.com/package/gulp-real-favicon) Generate a multiplatform favicon with [RealFaviconGenerator](https://realfavicongenerator.net)

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
       "babel-polyfill"
     ]
   },
-  "react-native": {
-    "uuid": "react-native-uuid"
-  },
   "dependencies": {
     "autoprefixer": "^6.1.0",
     "ava": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
       "babel-polyfill"
     ]
   },
+  "react-native": {
+    "uuid": "react-native-uuid"
+  },
   "dependencies": {
     "autoprefixer": "^6.1.0",
     "ava": "^0.16.0",
@@ -100,6 +103,7 @@
     "react-native-fbsdk": "^0.3.0",
     "react-native-locale": "0.0.11",
     "react-native-side-menu": "^0.20.0",
+    "react-native-uuid": "^1.4.8",
     "react-native-vector-icons": "^2.0.3",
     "react-redux": "^4.0.0",
     "react-router": "^2.3.0",
@@ -120,7 +124,6 @@
     "run-sequence": "^1.0.2",
     "sass-loader": "^4.0.0",
     "serialize-javascript": "^1.1.2",
-    "shortid": "^2.2.4",
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.0",
     "style-loader": "^0.13.0",
@@ -128,6 +131,7 @@
     "transit-immutable-js": "^0.6.0",
     "transit-js": "^0.8.846",
     "url-loader": "^0.5.5",
+    "uuid": "^2.0.2",
     "validator": "^5.0.0",
     "webpack": "^1.12.3",
     "webpack-dev-middleware": "^1.2.0",

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -4,6 +4,7 @@ import configureReporting from '../common/configureReporting';
 import configureStore from '../common/configureStore';
 import createRoutes from './createRoutes';
 import createStorageEngine from 'redux-storage-engine-localstorage';
+import uuid from 'uuid';
 import { Provider } from 'react-redux';
 import { Router, applyRouterMiddleware, browserHistory } from 'react-router';
 import { fromJSON } from '../common/transit';
@@ -18,7 +19,7 @@ const reportingMiddleware = configureReporting({
 });
 const store = configureStore({
   initialState,
-  platformDeps: { createStorageEngine },
+  platformDeps: { createStorageEngine, uuid },
   platformMiddleware: [reportingMiddleware, routerMiddleware(browserHistory)],
 });
 const history = syncHistoryWithStore(browserHistory, store);

--- a/src/common/configureMiddleware.js
+++ b/src/common/configureMiddleware.js
@@ -4,8 +4,8 @@ import errorToMessage from '../common/app/errorToMessage';
 
 // Deps.
 import firebase from 'firebase';
-import shortid from 'shortid';
 import validate from './validate';
+import uuid from 'uuid';
 
 let firebaseDeps = null;
 
@@ -64,7 +64,7 @@ export default function configureMiddleware(initialState, platformDeps, platform
     injectMiddleware({
       ...platformDeps,
       ...firebaseDeps,
-      getUid: () => shortid.generate(),
+      getUid: () => uuid.v4(),
       now: () => Date.now(),
       storageEngine,
       validate,

--- a/src/common/configureMiddleware.js
+++ b/src/common/configureMiddleware.js
@@ -5,7 +5,6 @@ import errorToMessage from '../common/app/errorToMessage';
 // Deps.
 import firebase from 'firebase';
 import validate from './validate';
-import uuid from 'uuid';
 
 let firebaseDeps = null;
 
@@ -64,7 +63,7 @@ export default function configureMiddleware(initialState, platformDeps, platform
     injectMiddleware({
       ...platformDeps,
       ...firebaseDeps,
-      getUid: () => uuid.v4(),
+      getUid: () => platformDeps.uuid.v4(),
       now: () => Date.now(),
       storageEngine,
       validate,

--- a/src/native/main.js
+++ b/src/native/main.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import configureStore from '../common/configureStore';
 import createRoutes from './createRoutes';
 import createStorageEngine from 'redux-storage-engine-reactnativeasyncstorage';
+import uuid from 'react-native-uuid';
 import { AppRegistry, Platform } from 'react-native';
 import { Provider } from 'react-redux';
 import { fromJSON } from '../common/transit';
@@ -30,7 +31,7 @@ const createNativeInitialState = () => ({
 
 const store = configureStore({
   initialState: createNativeInitialState(),
-  platformDeps: { FBSDK, createStorageEngine },
+  platformDeps: { FBSDK, createStorageEngine, uuid },
 });
 const routes = createRoutes();
 


### PR DESCRIPTION
Use 'uuid' package in place of 'shortid', and switch to 'react-native-uuid' on react-native.

Fixes a problem in Windows where react-native would not load the 'crypto' package.

See este/este#1033