### PR TITLE
Support for nested `Formatted*`

### DIFF
--- a/src/native/app/components/formatted.js
+++ b/src/native/app/components/formatted.js
@@ -1,5 +1,5 @@
 import * as reactIntl from 'react-intl';
-import React from 'react';
+import React, { Children } from 'react';
 import Text from './Text';
 
 // Create react-intl component which work in the React Native.
@@ -28,14 +28,14 @@ const native = WrappedComponent =>
 
       return (
         <WrappedComponent {...wrappedComponentProps}>
-          {message => childrenAsFunction ?
-            children(message)
+          {nodes => childrenAsFunction ?
+            children(...Children.toArray(nodes))
           :
             <Text
               ref={text => this.onTextRef(text)}
               style={style}
             >
-              {message}
+              {Children.toArray(nodes)}
             </Text>
           }
         </WrappedComponent>


### PR DESCRIPTION
The current wrapper for `Formatted*` in React Native doesn't support nested `Formatted*` such as below. This PR will fix this problem and make it work as normal.
```jsx
<FormattedMessage
  id='app.greeting'
  defaultMessage='{hello}, {name}!'
  values={{
    hello: <FormattedMessage id='app.hello' defaultMessage='Hello' />,
    name: 'James',
  }}
/>
```