### PR TITLE
using location.pathname as key to StaticRouter

### DIFF
--- a/src/browser/app/Root.js
+++ b/src/browser/app/Root.js
@@ -24,7 +24,7 @@ const Router = ({ dispatch, pathname }: RouterProps) => (
         <StaticRouter
           action={action}
           blockTransitions={history.block}
-          key={pathname} // github.com/yahoo/react-intl/issues/234#issuecomment-163366518
+          key={location.pathname} // github.com/yahoo/react-intl/issues/234#issuecomment-163366518
           location={location}
           onPush={history.push}
           onReplace={history.replace}


### PR DESCRIPTION
I'm not really sure why we use `pathname` here. The link talks about Int'l so I couldn't make the connection, but I guess it got something to do with the need to completely rebuild the components tree on path change (why the page don't changes without it?).

I do know that since the first `pathname` is always `null` (initial state) then on first load from server it always makes the whole app tree unmount and mount again. You can't really notice it with only stateless components, but when a stateful component mounts, unmounts and mounts again, its a big useless hassle.

I let myself offer this small change because I guess it's aligned with the original intent. Please ignore this pull request if I haven't got it correct. 