### PR TITLE
Fixed webpack SVG and webfont loader tests to match .svg?v=1.0 etc.

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -61,13 +61,13 @@ const makeConfig = options => {
       loaders: [
         {
           loader: 'url-loader?limit=10000',
-          test: /\.(gif|jpg|png|svg)$/,
+          test: /\.(gif|jpg|png|svg(\?[a-z0-9\.=]+)*)$/,
         }, {
           loader: 'url-loader?limit=1',
           test: /favicon\.ico$/,
         }, {
           loader: 'url-loader?limit=100000',
-          test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9]+)?$/,
+          test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9\.=]+)?$/,
         }, {
           test: /\.js$/,
           exclude: constants.NODE_MODULES_DIR,

--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -61,13 +61,13 @@ const makeConfig = options => {
       loaders: [
         {
           loader: 'url-loader?limit=10000',
-          test: /\.(gif|jpg|png|svg(\?[a-z0-9\.=]+)*)$/,
+          test: /\.(gif|jpg|png|svg)(\?.*)?$/,
         }, {
           loader: 'url-loader?limit=1',
           test: /favicon\.ico$/,
         }, {
           loader: 'url-loader?limit=100000',
-          test: /\.(ttf|eot|woff(2)?)(\?[a-z0-9\.=]+)?$/,
+          test: /\.(ttf|eot|woff|woff2)(\?.*)?$/,
         }, {
           test: /\.js$/,
           exclude: constants.NODE_MODULES_DIR,


### PR DESCRIPTION
I was trying to add font-awesome to my project and encountered problem with webpack not able to parse `.svg?v=4.7.0`, same thing with webfonts.

This PR should fix the issue while not break up anything else.
PS: I am not that good with expressions, double-check it please.