### PR TITLE
Update redux repo url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Libraries
 
-- [redux](http://rackt.github.io/redux/)
+- [redux](http://reactjs.github.io/redux/)
 - [redux-observable](https://github.com/redux-observable/redux-observable)
 - [ramda](http://ramdajs.com/)
 - [react-intl](https://github.com/yahoo/react-intl)


### PR DESCRIPTION
I recently noticed that somebody now has the username `rackt` after the account was (presumably) deleted when `rackt` repos were assigned to the `reactjs` organisation.
This person has also created a repo named `redux` so now all links to `rackt/redux` point to that (usually when a repo gets a new home, GH handles the redirecting).

Take a look: http://rackt.github.io/redux/