### PR TITLE
Upgrade react-redux to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-side-menu": "^0.20.0",
     "react-native-uuid": "^1.4.8",
     "react-native-vector-icons": "^3.0.0",
-    "react-redux": "^4.0.0",
+    "react-redux": "^5.0.1",
     "react-router": "4.0.0-alpha.6",
     "rebass": "^0.3.1",
     "redbox-react": "^1.0.5",


### PR DESCRIPTION
Upgrade react-redux to v5 as it requires no code changes due to backward compatibility and claims significant performance improvements.[https://github.com/reactjs/react-redux/releases/tag/v5.0.0](https://github.com/reactjs/react-redux/releases/tag/v5.0.0)