### PR TITLE
Remove syntax error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,7 @@ module.exports = {
           analyzerMode: 'server',
           analyzerPort: 8888,
           openAnalyzer: true,
-        }),
+        })
       );
     }
 


### PR DESCRIPTION
Syntax error caused from extra comma in next.config.js. Node version 6.11.1

```
next.config.js:16
      );
      ^
SyntaxError: Unexpected token )
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:542:28)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at loadConfig (/Users/Thakkery/Documents/Omninox/Growth/react_attendance_tracker/attendance/node_modules/next/dist/server/config.js:57:28)
error Command failed with exit code 1.
```