### PR TITLE
Simplify typography calculations

### DIFF
--- a/themes/typography.js
+++ b/themes/typography.js
@@ -33,17 +33,16 @@ const typography = ({
   fontSize: number,
   fontSizeScale: number | $Keys<typeof scale>,
   lineHeight: number,
-|}) => ({
-  fontSize: (level: number) =>
-    Array.from(Array(Math.abs(level))).reduce(size => {
-      const scaleRatio =
-        typeof fontSizeScale === 'string'
-          ? scale[fontSizeScale]
-          : fontSizeScale;
-      return level > 0 ? size * (1 / scaleRatio) : size / (1 / scaleRatio);
-    }, fontSize),
-  lineHeight,
-  rhythm: (ratio: number) => lineHeight * ratio,
-});
+|}) => {
+  const scaleRatio =
+    typeof fontSizeScale === 'string'
+      ? scale[fontSizeScale]
+      : fontSizeScale;
+  return {
+    fontSize: (level: number) => fontSize ** (scaleRatio, -level),
+    lineHeight,
+    rhythm: (ratio: number) => lineHeight * ratio,
+  };
+};
 
 export default typography;


### PR DESCRIPTION
Gravely simplifies the typography calculations by using powers instead of reducing over an array.

This code should be more performant since we do not need to allocate arrays at all and it certainly has a clearer intent.