### PR TITLE
Setup cookies path when setting/deleting

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -11,15 +11,21 @@ const tokenKey = 'este_auth_token';
 const userIdKey = 'este_user_id';
 
 export const setCookie = (cookie: Cookie) => {
-  // One month, it's graph.cool default.
-  const options = { maxAge: 30 * 24 * 60 * 60 };
+  const options = {
+    maxAge: 30 * 24 * 60 * 60, // One month, it's graph.cool default.
+    path: '/',
+  };
+
   document.cookie = serialize(tokenKey, cookie.token, options);
   document.cookie = serialize(userIdKey, cookie.userId, options);
 };
 
 export const deleteCookie = () => {
-  // Expire the cookie immediately.
-  const options = { maxAge: -1 };
+  const options = {
+    maxAge: -1, // Expire the cookie immediately.
+    path: '/',
+  };
+
   document.cookie = serialize(tokenKey, '', options);
   document.cookie = serialize(userIdKey, '', options);
 };


### PR DESCRIPTION
Deleting a cookie(s) is not 100% reliable when only `name` of the cookie is provided. Cookie won't delete from nested URL path like `/dashboard/user/profile`. See [this SO answer](https://stackoverflow.com/questions/595228/how-can-i-delete-all-cookies-with-javascript/2421786#2421786) how to properly delete cookie.

In my project, adding `path` option during delete procedure fixed unreliable cookie(s) removal.