### PR TITLE
form submit prevent default

### DIFF
--- a/components/core/Form.js
+++ b/components/core/Form.js
@@ -23,6 +23,7 @@ class Form extends React.PureComponent<FormProps> {
     if (e.key !== 'Enter') return;
     if (typeof this.props.onSubmit !== 'function') return;
     this.props.onSubmit();
+    e.preventDefault();
   };
 
   render() {


### PR DESCRIPTION
Pressing Enter would cause the page to refresh, as normal post behavior would occur.