### PR TITLE
Add docker-compose for dev environment

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,4 @@
-PRISMA_ENDPOINT=https://eu1.prisma.sh/daniel-steigerwald/Este/dev
+PRISMA_ENDPOINT=http://localhost:4466
 PRISMA_SECRET=prismaSecret
 # For testing in Virtual Windows
 #API_ENDPOINT=http://10.0.1.3:4000

--- a/README.md
+++ b/README.md
@@ -14,11 +14,21 @@ Universal React. React + React Native.
 - `cd este`
 - `yarn`
 
-## Create dev Prisma
+## Create Prisma Service
+
+### Option A - Prisma Server on Prisma.io
 
 - `yarn prisma init YourAppName` choose `Demo server`
 - set `.env.dev` PRISMA_ENDPOINT by `YourAppName/prisma.yml` endpoint
 - delete `YourAppName` directory
+
+### Option B - Prisma Server with Docker Compose *[requires docker-compose]*
+
+- `yarn docker:up` -- this will spin up a docker instance of Postgres and prisma server at http://localhost:4466
+- `yarn docker:down` -- stop docker-compose servers
+
+## Deploy dev Prisma
+
 - `yarn env dev`
 - `yarn deploy:db`
 - `yarn prisma token` generate token

--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  prisma:
+    image: prismagraphql/prisma:1.13
+    restart: always
+    ports:
+    - "4466:4466"
+    environment:
+      PRISMA_CONFIG: |
+        port: 4466
+        # uncomment the next line and provide the env var PRISMA_MANAGEMENT_API_SECRET=my-secret to activate cluster security
+        # managementApiSecret: my-secret
+        databases:
+          default:
+            connector: postgres
+            host: postgres
+            port: 5432
+            user: prisma
+            password: prisma
+            migrations: true
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: prisma
+      POSTGRES_PASSWORD: prisma
+    volumes:
+      - postgres:/var/lib/postgresql/data
+volumes:
+  postgres:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "deps": "rimraf 'node_modules' 'yarn.lock' 'flow-typed' && yarn && flow-typed install",
     "env": "node -r esm -r flow-remove-types/register ./scripts/env",
     "analyze:bundles": "cross-env ANALYZE=BUNDLES next build",
-    "analyze:size": "cross-env ANALYZE=SIZE next build && cat '.next/stats.txt'"
+    "analyze:size": "cross-env ANALYZE=SIZE next build && cat '.next/stats.txt'",
+    "docker:up": "cd database && docker-compose up -d && cd ../",
+    "docker:down": "cd database && docker-compose down && cd ../"
   },
   "dependencies": {
     "accepts": "^1.3.3",


### PR DESCRIPTION
Init dev environment quicker with docker-compose, by just cloning the repo and then running `yarn docker:up`

Instead of having to do a `prisma init {APP_NAME}`, go through the setup, then copy the PRISMA_ENDPOINT, past the endpoint, then remove the new directory. 

Docker compose instantly spins up the prisma server and postgres database, and then surfaces the localhost:4466 endpoint.

Everything else including `yarn deploy:db` works exactly the same. But now you are running locally on machine, instead of a remote prisma server.